### PR TITLE
Fix: migrate legacy EnderDB keys and recover AEItemKeys (Provided By CubedWorlds)

### DIFF
--- a/neoforge/src/main/java/com/sts15/enderdrives/db/EnderDBManager.java
+++ b/neoforge/src/main/java/com/sts15/enderdrives/db/EnderDBManager.java
@@ -144,14 +144,75 @@ public class EnderDBManager {
     /**
      * Retrieves the stored count of an item in the database.
      *
-     * @param scopePrefix The scope name.
-     * @param freq        The frequency ID.
-     * @param keyBytes The serialized item key.
-     * @return The current stored count for the item.
+     * This method first does the direct byte[] key lookup (fast path). If that returns 0,
+     * it will attempt a semantic lookup by deserializing the provided bytes to an AEItemKey
+     * and summing any entries in the same scope/frequency whose stored AEItemKey equals it.
+     *
+     * If any legacy entries are found that match by AEItemKey but use different byte[] keys,
+     * they will be merged into the canonical key (the provided keyBytes) to avoid future mismatches.
      */
     public static long getItemCount(String scopePrefix, int freq, byte[] keyBytes) {
         AEKey key = new AEKey(scopePrefix, freq, keyBytes);
-        return dbMap.getOrDefault(key, new StoredEntry(0L, null)).count();
+        // Fast direct lookup first
+        StoredEntry direct = dbMap.get(key);
+        long directCount = direct == null ? 0L : direct.count();
+        if (directCount > 0) return directCount;
+
+        // Fallback: try to deserialize provided bytes into AEItemKey and match by AEItemKey equality.
+        AEItemKey requestedAek = null;
+        try {
+            ItemStack s = deserializeItemStackFromBytes(keyBytes);
+            if (!s.isEmpty()) requestedAek = AEItemKey.of(s);
+        } catch (Exception ignored) {}
+
+        if (requestedAek == null) return 0L;
+
+        // Scan the frequency submap to find matching AEItemKeys (this finds legacy/alternate-key entries)
+        AEKey from = new AEKey(scopePrefix, freq, new byte[0]);
+        AEKey to   = new AEKey(scopePrefix, freq + 1, new byte[0]);
+
+        long sum = 0L;
+        List<AEKey> keysToMerge = new ArrayList<>();
+
+        // Synchronize on commitLock to safely inspect and mutate dbMap for merging
+        synchronized (commitLock) {
+            NavigableMap<AEKey, StoredEntry> sub = dbMap.subMap(from, true, to, false);
+            for (Map.Entry<AEKey, StoredEntry> e : sub.entrySet()) {
+                StoredEntry stored = e.getValue();
+                AEItemKey storedAek = stored.aeKey();
+
+                // If stored aeKey is null, attempt to lazily recover it from the stored bytes
+                if (storedAek == null) {
+                    try {
+                        ItemStack s2 = deserializeItemStackFromBytes(e.getKey().itemBytes());
+                        if (!s2.isEmpty()) storedAek = AEItemKey.of(s2);
+                    } catch (Exception ignored) {}
+                }
+
+                if (storedAek != null && storedAek.equals(requestedAek)) {
+                    sum += stored.count();
+                    keysToMerge.add(e.getKey());
+                }
+            }
+
+            if (sum > 0) {
+                // Merge found legacy entries into the canonical key (the provided keyBytes)
+                long existing = dbMap.getOrDefault(key, new StoredEntry(0L, null)).count();
+                long newCount = existing + sum;
+                dbMap.put(key, new StoredEntry(newCount, requestedAek));
+
+                // Remove legacy keys (except when one of them already equals the canonical key)
+                for (AEKey k : keysToMerge) {
+                    if (!Arrays.equals(k.itemBytes(), keyBytes)) {
+                        dbMap.remove(k);
+                    }
+                }
+
+                dirty = true;
+            }
+        }
+
+        return sum;
     }
 
 
@@ -209,6 +270,9 @@ public class EnderDBManager {
 
     /**
      * Queries all items for a scope/freq, merging committed + pending.
+     *
+     * This now attempts to repair entries that have null aeKey by deserializing their byte[] and
+     * updating the StoredEntry with an AEItemKey where possible so they are visible to callers.
      */
     public static List<AEKeyCacheEntry> queryItemsByFrequency(String scopePrefix, int freq) {
         AEKey lo = new AEKey(scopePrefix, freq,   new byte[0]);
@@ -216,15 +280,49 @@ public class EnderDBManager {
         NavigableMap<AEKey, StoredEntry> committed = dbMap.subMap(lo, true, hi, false);
 
         List<AEKeyCacheEntry> result = new ArrayList<>();
+        // We may need to update some entries with recovered AEItemKey instances.
+        List<AEKey> keysToUpdate = new ArrayList<>();
+        Map<AEKey, AEItemKey> recovered = new HashMap<>();
+
         for (var e : committed.entrySet()) {
             long cnt = e.getValue().count();
             if (cnt <= 0) continue;
             AEKey k = e.getKey();
             AEItemKey aek = e.getValue().aeKey();
+
+            if (aek == null) {
+                // Try to recover AEItemKey lazily
+                try {
+                    ItemStack s = deserializeItemStackFromBytes(k.itemBytes());
+                    if (!s.isEmpty()) {
+                        AEItemKey derived = AEItemKey.of(s);
+                        aek = derived;
+                        keysToUpdate.add(k);
+                        recovered.put(k, derived);
+                    }
+                } catch (Exception ignored) {}
+            }
+
             if (aek != null) {
                 result.add(new AEKeyCacheEntry(k, aek, cnt));
             }
         }
+
+        // Apply any recovered AEItemKey instances back into the map under commitLock so future queries are fast.
+        if (!keysToUpdate.isEmpty()) {
+            synchronized (commitLock) {
+                for (AEKey k : keysToUpdate) {
+                    StoredEntry old = dbMap.get(k);
+                    if (old == null) continue; // might have been removed concurrently
+                    AEItemKey newAek = recovered.get(k);
+                    if (newAek != null) {
+                        dbMap.put(k, new StoredEntry(old.count(), newAek));
+                        dirty = true;
+                    }
+                }
+            }
+        }
+
         return result;
     }
 


### PR DESCRIPTION
- Add a safe fallback lookup to EnderDBManager#getItemCount:
  * Try direct byte[] key lookup (fast path).
  * If missing, deserialize the requested bytes to an AEItemKey and scan the frequency submap
    for stored entries whose AEItemKey equals the requested one (this finds legacy/alternate-key entries).
  * Sum matching legacy entries and merge them into the canonical (current) key.
  * All mutations happen under commitLock and set the DB dirty for normal WAL/commit.

- Improve EnderDBManager#queryItemsByFrequency:
  * Lazily attempt to recover null AEItemKey values by deserializing stored item bytes.
  * Write recovered AEItemKey back into dbMap under commitLock so future queries are fast
    and UI/commands (dump, export, etc.) see legacy entries.

- Rationale:
  * Old DB records used different serialized keys; AE2 shows aggregated stacks but extraction
    relied on exact byte[] keys, leaving legacy items "stuck".
  * This change provides an on-the-fly, conservative migration so previously stuck items become
    extractable and visible without a heavy offline migration.

- Safety & notes:
  * Merges are done while holding commitLock and mark the DB dirty so WAL/commit logic persists changes.
  * The code attempts to be conservative: it derives AEItemKey only when needed and only when it can be deserialized.
  * Recommend backing up `saves/<world>/data/enderdrives/enderdrives.bin` before bulk operations.
  * Enable END_DB_DEBUG_LOG for verbose migration logs during testing.

Test plan:
1. Backup world/data/enderdrives/enderdrives.bin
2. Start server and enable END_DB_DEBUG_LOG (optional).
3. Confirm previously stuck legacy items are now listed by `/enderdrives dumpcell <scope> <freq>` and can be extracted.
4. Insert new items and ensure normal insert/extract behavior remains unchanged.
5. Verify db file grows/changes and that WAL commits as expected.